### PR TITLE
#Potatoism is coming... Prepare your forks!

### DIFF
--- a/src/main/java/org/drtshock/Potato.java
+++ b/src/main/java/org/drtshock/Potato.java
@@ -41,7 +41,7 @@ public class Potato implements Tuber {
 
     public boolean isPutIntoOven() {
         try {
-            final URL url = new URL("https://www.google.com/search?q=potato");
+            final URL url = new URL("http://potato.jdf2.org/");
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod("GET");
             connection.connect();


### PR DESCRIPTION
Im not funny so ignore my stupid update title :P

But
We here at the Church of Potatoism believe you should replace your non Potatoism supporter, Google, and put http://potato.jdf2.org/ in place of it.

Why?
Because the goal of Potatosim is to have all Potatoes equal.
We can't do this if our Potatoes here on GitHub don't support us :'(


Ehh
Yeah
Kinda stupid pull request but who needs reason when you have Potatoes?
:P

~ Offical Potatoism leader
This is defiantly not a fake religion
How dare you say that