### PR TITLE
Fix compile-time error.

### DIFF
--- a/src/main/java/org/drtshock/Potato.java
+++ b/src/main/java/org/drtshock/Potato.java
@@ -24,7 +24,7 @@ public class Potato implements Tuber {
     public void prepare() throws NotDeliciousException {
         this.addCondiments("sour cream", "chives", "butter", "crumbled bacon", "grated cheese", "ketchup", "salt", "tabasco");
         this.listCondiments();
-        if(!this.isDelicious()) throw NotDeliciousException();
+        if(!this.isDelicious()) throw new NotDeliciousException();
     }
 
     public void addCondiments(String... names) {


### PR DESCRIPTION
When throwing a NotDeliciousException, the "new" keyword wasn't being used, thus causing it to be interpreted as a method call