### PR TITLE
Add the OvenException to allow for proper handling of oven-related ex…

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ If you have forked the potato and are looking to submit a pull request, please a
 - Make sure that your code compiles and runs, if you are changing code.
 - Please format your code.
 - Our potato is a mainstream potato; it doesn't enjoy being full of obscure code/references (not a hipster potato).
-- Please "mash your Potatoes" (Squash your PRs with interactive rebase).
-- If a comment is made on your PR, inquiring for more info, a reply is expected within a week. The request will be closed if not.
+- Please "mash your potatoes" (squash your PRs with interactive rebase).
+- If a comment inquiring for more information is made on your PR, a reply is expected within a week. The request will be closed if not.
 - To stress: **no non-potato-related items**.

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,11 @@
           <finalName>Potato</finalName>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.10.3</version>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/src/main/java/org/drtshock/OvenException.java
+++ b/src/main/java/org/drtshock/OvenException.java
@@ -1,0 +1,10 @@
+package org.drtshock;
+
+/**
+ * Thrown when the oven interface itself is experiencing exceptions.
+ */
+public class OvenException extends Exception {
+    public OvenException(){
+
+    }
+}

--- a/src/main/java/org/drtshock/OvenException.java
+++ b/src/main/java/org/drtshock/OvenException.java
@@ -4,7 +4,7 @@ package org.drtshock;
  * Thrown when the oven interface itself is experiencing exceptions.
  */
 public class OvenException extends Exception {
-    public OvenException(){
-
+    public OvenException(Exception internalException){
+        super(internalException);
     }
 }

--- a/src/main/java/org/drtshock/Potato.java
+++ b/src/main/java/org/drtshock/Potato.java
@@ -83,7 +83,7 @@ public class Potato implements Tuber {
             int inOven = connection.getResponseCode();
             return inOven == 200;
         } catch (IOException ex) {
-            throw new OvenException();
+            throw new OvenException(ex);
         }
     }
 

--- a/src/main/java/org/drtshock/Potato.java
+++ b/src/main/java/org/drtshock/Potato.java
@@ -72,8 +72,9 @@ public class Potato implements Tuber {
      * Checks if the potato is put into the oven.
      *
      * @return true if potato is in the oven, false if otherwise
+     * @throws OvenException if the oven is experiencing internal exceptions
      */
-    public boolean isPutIntoOven() {
+    public boolean isPutIntoOven() throws OvenException {
         try {
             final URL url = new URL("https://www.google.com/search?q=potato");
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
@@ -82,8 +83,7 @@ public class Potato implements Tuber {
             int inOven = connection.getResponseCode();
             return inOven == 200;
         } catch (IOException ex) {
-            ex.printStackTrace();
-            return false;
+            throw new OvenException();
         }
     }
 
@@ -93,7 +93,11 @@ public class Potato implements Tuber {
      * @return true if this potato is baked, false if otherwise
      */
     public boolean isBaked() {
-        return this.isPutIntoOven();
+        try {
+            return this.isPutIntoOven();
+        } catch (OvenException e) {
+            return false; //If the oven is malfunctioning, then the potato cannot be cooked, and therefore not baked.
+        }
     }
 
     /**

--- a/src/main/java/org/drtshock/Potato.java
+++ b/src/main/java/org/drtshock/Potato.java
@@ -16,10 +16,10 @@ public class Potato implements Tuber {
     public static void main(String[] args) {
         final Potato potato = new Potato();
         try {
-        	potato.prepare();
-        	System.out.println("Of course potato is prepared and delicious.");
+            potato.prepare();
+            System.out.println("Of course potato is prepared and delicious.");
         } catch (NotDeliciousException e) {
-        	System.err.println("Fatal error! How could potato not be delicious?");
+            System.err.println("Fatal error! How could potato not be delicious?");
         }
     }
 


### PR DESCRIPTION
…ceptions

We should not be printing the stack trace of the oven related exception. Simply accept that the potato is not baked. This will in turn, throw an PotatoNotDelicious exception, however, I believe this is better handling of these oven based issues.