### PR TITLE
Add version number to user agent

### DIFF
--- a/src/main/java/org/drtshock/Potato.java
+++ b/src/main/java/org/drtshock/Potato.java
@@ -80,7 +80,7 @@ public class Potato implements Tuber {
             final URL url = new URL("https://www.google.com/search?q=potato");
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod("GET");
-            connection.addRequestProperty("User-Agent", "Potato");
+            connection.addRequestProperty("User-Agent", "Potato/1.7.5");
             connection.connect();
             int inOven = connection.getResponseCode();
             return inOven == 200;


### PR DESCRIPTION
Without a version number, web servers are not able to distinguish between potato versions. This is very important, because if an old potato is left lying around for too long, it might start to rot. By comparing the version number against a recent version, web servers can be certain that they're only accepting fresh, delicious potatoes.