### PR TITLE
isCooked documentation returns boiled not baked

### DIFF
--- a/src/main/java/org/drtshock/Potato.java
+++ b/src/main/java/org/drtshock/Potato.java
@@ -105,7 +105,7 @@ public class Potato implements Tuber {
     /**
      * Checks if this potato is cooked. Returns the result of {@link #hasBeenBoiledInWater()}.
      *
-     * @return true if this potato is baked, false if otherwise
+     * @return true if this potato is boiled, false if otherwise
      */
     public boolean isCooked() {
         try {


### PR DESCRIPTION
Javadoc of #isCooked shouldn't say baked, it should say boiled to make sure we aren't deceiving people about the deliciousness.