### PR TITLE
Split BurntException into two subclasses

### DIFF
--- a/src/main/java/org/drtshock/BakedTooLongException.java
+++ b/src/main/java/org/drtshock/BakedTooLongException.java
@@ -1,0 +1,12 @@
+package org.drtshock;
+
+/**
+ * An exception to describe that our potato was baked too long!
+ */
+public class BakedTooLongException extends BurntException {
+
+    public BakedTooLongException(long bakeTime) {
+        super("Potato is badly burnt by baking for too long!! (" + bakeTime + "ms)");
+    }
+
+}

--- a/src/main/java/org/drtshock/BoiledTooHotException.java
+++ b/src/main/java/org/drtshock/BoiledTooHotException.java
@@ -1,0 +1,12 @@
+package org.drtshock;
+
+/**
+ * An exception to describe that our potato was boiled too hot!
+ */
+public class BoiledTooHotException extends BurntException {
+
+    public BoiledTooHotException(int degrees) {
+        super("Potato is badly burnt by trying to boil it at " + degrees + " degrees!!");
+    }
+
+}

--- a/src/main/java/org/drtshock/BurntException.java
+++ b/src/main/java/org/drtshock/BurntException.java
@@ -1,16 +1,16 @@
 package org.drtshock;
 
 /**
- * An exception to describe that something went wrong with our oven!
+ * An exception to describe that our potato was burnt!
  */
 public class BurntException extends Exception {
 
-    public BurntException(int degrees) {
-        super("Potato is badly burnt by trying to boil it at " + degrees + " degrees!!");
+    public BurntException() {
+        super("Potato is badly burnt!!");
     }
 
-    public BurntException(long bakeTime) {
-        super("Potato is badly burnt by baking for too long!! (" + bakeTime + "ms)");
+    public BurntException(String reason) {
+        super(reason);
     }
 
 }

--- a/src/main/java/org/drtshock/Potato.java
+++ b/src/main/java/org/drtshock/Potato.java
@@ -86,7 +86,7 @@ public class Potato implements Tuber {
             connection.connect();
             int inOven = connection.getResponseCode();
             long bakeTime = (System.currentTimeMillis() - begin);
-            if (bakeTime > 1100) throw new BurntException(bakeTime);
+            if (bakeTime > 1100) throw new BakedTooLongException(bakeTime);
             return inOven == 200;
         } catch (IOException ex) {
             throw new OvenException(ex);
@@ -118,7 +118,7 @@ public class Potato implements Tuber {
         if (waterDegrees < 70) {
             return false;
         } else if (waterDegrees > 130) {
-            throw new BurntException(waterDegrees);
+            throw new BoiledTooHotException(waterDegrees);
         }
         return true;
     }


### PR DESCRIPTION
Currently BurntException represents two distinct situations, which are distinguished by the type of the number passed to the constructor (yikes!). Split into two subclasses.