### PR TITLE
Split BurntException into two subexceptions.

### DIFF
--- a/src/main/java/org/drtshock/BurntException.java
+++ b/src/main/java/org/drtshock/BurntException.java
@@ -5,12 +5,16 @@ package org.drtshock;
  */
 public class BurntException extends Exception {
 
-    public BurntException(int degrees) {
-        super("Potato is badly burnt by trying to boil it at " + degrees + " degrees!!");
+    public BurntException(String message) {
+        super(message);
     }
 
-    public BurntException(long bakeTime) {
-        super("Potato is badly burnt by baking for too long!! (" + bakeTime + "ms)");
+    public BurntException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public BurntException(Throwable cause) {
+        super(cause);
     }
 
 }

--- a/src/main/java/org/drtshock/BurntTemperatureException.java
+++ b/src/main/java/org/drtshock/BurntTemperatureException.java
@@ -1,0 +1,25 @@
+package org.drtshock;
+
+/**
+ * An exception which describes that the oven burnt the potato via too high of temperature
+ */
+public class BurntTemperatureException extends BurntException {
+
+    private final int degrees;
+
+    /**
+     * @param degrees The temperature at which the potato was cooked too hot and caused burns
+     */
+    public BurntTemperatureException(int degrees) {
+        super("Potato is badly burnt by trying to boil it at " + degrees + " degrees!!");
+        this.degrees = degrees;
+    }
+
+    /**
+     * @return The temperature at which the potato was cooked too hot
+     */
+    public int getDegrees() {
+        return degrees;
+    }
+
+}

--- a/src/main/java/org/drtshock/BurntTimeException.java
+++ b/src/main/java/org/drtshock/BurntTimeException.java
@@ -1,0 +1,25 @@
+package org.drtshock;
+
+/**
+ * An exception to describe that while cooking the potato, it was burnt due to being cooked for too long.
+ */
+public class BurntTimeException extends BurntException {
+
+    private final long bakeTime;
+
+    /**
+     * @param bakeTime The time the potato was baked, in milliseconds.
+     */
+    public BurntTimeException(long bakeTime) {
+        super("Potato is badly burnt by baking for too long!! (" + bakeTime + "ms)");
+        this.bakeTime = bakeTime;
+    }
+
+    /**
+     * @return The time the potato was baked in milliseconds.
+     */
+    public long getBakeTime() {
+        return bakeTime;
+    }
+
+}

--- a/src/main/java/org/drtshock/Potato.java
+++ b/src/main/java/org/drtshock/Potato.java
@@ -86,7 +86,7 @@ public class Potato implements Tuber {
             connection.connect();
             int inOven = connection.getResponseCode();
             long bakeTime = (System.currentTimeMillis() - begin);
-            if (bakeTime > 1100) throw new BurntException(bakeTime);
+            if (bakeTime > 1100) throw new BurntTimeException(bakeTime);
             return inOven == 200;
         } catch (IOException ex) {
             throw new OvenException(ex);
@@ -118,7 +118,7 @@ public class Potato implements Tuber {
         if (waterDegrees < 70) {
             return false;
         } else if (waterDegrees > 130) {
-            throw new BurntException(waterDegrees);
+            throw new BurntTemperatureException(waterDegrees);
         }
         return true;
     }


### PR DESCRIPTION
BurntException initially was thrown whenever a burn condition on the
potato was detected, however the constructors for BurntException were
very similar and could have collided. Instead, split it out into two new
exceptions - BurntTimeException and BurntTemperatureException.