### PR TITLE
Remove discord invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 Potato
 ======
 
-[![Discord](https://i.imgur.com/HLPoNnY.png)](https://discord.gg/5hBDT2P)
-
 If you fork this you can say that you forked a potato.
 
 ![potato](http://i.imgur.com/dRnvRZZ.jpg)


### PR DESCRIPTION
Discord link doesn't seem to be potato related, it contradicts rule 1 of potato: `Our potato is lightweight, and it doesn't need non-potato-related items.`