### PR TITLE
Added disclaimer for vegan potatoes

### DIFF
--- a/src/main/java/org/drtshock/Potato.java
+++ b/src/main/java/org/drtshock/Potato.java
@@ -16,7 +16,10 @@ public class Potato implements Tuber {
 
     public static void main(String[] args) {
         final Potato potato = new Potato(args.length == 1 && args[0].equals("--vegan"));
-        if (potato.isVegan) System.out.println("This potato is vegan.");
+        if (potato.isVegan) {
+            System.out.println("This potato is vegan.");
+            System.out.println("Product may contain butter. Potato industries and affiliates will not be held responsible for culinary dissatisfaction arising from consumption of vegan potatoes. Vegan is used as a marketting term only, and is not meant as a dietary guarentee.");
+        }
         try {
             potato.prepare();
             System.out.println("Of course Potato is prepared and delicious.");

--- a/src/main/java/org/drtshock/Potato.java
+++ b/src/main/java/org/drtshock/Potato.java
@@ -18,7 +18,7 @@ public class Potato implements Tuber {
         final Potato potato = new Potato(args.length == 1 && args[0].equals("--vegan"));
         if (potato.isVegan) {
             System.out.println("This potato is vegan.");
-            System.out.println("Product may contain butter. Potato industries and affiliates will not be held responsible for culinary dissatisfaction arising from consumption of vegan potatoes. Vegan is used as a marketting term only, and is not meant as a dietary guarentee.");
+            System.out.println("Product may contain butter. Potato industries and affiliates will not be held responsible for culinary dissatisfaction arising from consumption of vegan potatoes. Vegan is used as a marketing term only, and is not meant as a dietary guarantee.");
         }
         try {
             potato.prepare();


### PR DESCRIPTION
This disclaimer absolves Potato industries and all affiliates for liability in the case "vegan" potatoes allegedly contain butter.
Closes #162.
Corrects an edge case caused by #149.
