### PR TITLE
Keep Potato up to date

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.12.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -34,7 +34,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.4.1</version>
+                <version>3.6.3</version>
             </plugin>
             <plugin>
                 <groupId>net.orfjackal.retrolambda</groupId>


### PR DESCRIPTION
We want to keep the Potato lightweight. In that case, we need to keep it up to date so it can be as optimized as possible. Potato's version was not changed in this commit.