### PR TITLE
Fixed typo and improved clarity

### DIFF
--- a/src/main/java/org/drtshock/Potato.java
+++ b/src/main/java/org/drtshock/Potato.java
@@ -113,9 +113,9 @@ public class Potato implements Tuber {
     }
 
     /**
-     * Checks if the potato is succesfully boiled at the right amount of degrees.
+     * Checks if the potato is successfully boiled at the right amount of degrees.
      *
-     * @return true if the potato has succesfully been boiled, false if otherwise
+     * @return true if the potato has successfully been boiled, false if otherwise
      * @throws BurntException if the potato has been burned during the process of cooking
      */
     public boolean hasBeenBoiledInWater() throws BurntException {
@@ -195,7 +195,7 @@ public class Potato implements Tuber {
          * @return true if expired, false if otherwise
          */
         public boolean isExpired() {
-            return expired;
+            return this.expired;
         }
 
         /**


### PR DESCRIPTION
Explicitly use `this` to refer to the instance variable. This can improve clarity.